### PR TITLE
Endor Labs Version Upgrade: Bump com.fasterxml.jackson.core:jackson-databind from 2.9.10.3 to 2.17.1

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -18,7 +18,7 @@
     				<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.3</version>
+			<version>2.17.1</version>
 		</dependency>
         		<dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
<h1 align="center">
  Endor Labs Automated Dependency Update
</h1>

## Summary

This PR updates dependencies to improve security:

### 📦 Dependencies Updated

| Project | Dependency Name | Update Version (From ➡️ To) | Update Risk |    |
|---------|-----------------|----------------------------|-------------|----|
| [nztzsh/maven-multi-module](https://app.endorlabs.com/t/test_shiva.nitesh/projects/6710b55241465cc922c942f6) | `com.fasterxml.jackson.core:jackson-databind` | `2.9.10.3` ➡️ `2.17.1` | `HIGH` | [View Details](https://app.endorlabs.com/t/test_shiva.nitesh/projects/6710b55241465cc922c942f6/remediations?filter.search=com.fasterxml.jackson.core%3Ajackson-databind) |

---

## Security Impact

### Summary of Fixed Issues

| Severity | Count |
|----------|-------|
| ⛔ Critical | 3 |
| 🔴 High     | 35     |

<details>
  <summary>🔍 <b>Findings fixed in this pull request (Click to expand)</b> </summary>

| Advisory          | Dependency Reachability | Function Reachability | Severity    |
|-------------------|-------------------------|-----------------------|-------------|
| [GHSA-p43x-xfjf-5jhr](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ed23bbf7fc73b08d5) | Unreachable | Unreachable | ⛔ Critical |
| [GHSA-q93h-jc49-78gg](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e901233553167d24b) | Unreachable | Unreachable | ⛔ Critical |
| [GHSA-5p34-5m6p-p58g](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f4fbcbfe1576876fb) | Unreachable | Unreachable | ⛔ Critical |
| [GHSA-j823-4qch-3rgm](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ed23bbf7fc73b08d0) | Unreachable | Unreachable | 🔴 High |
| [GHSA-5r5r-6hpj-8gg9](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f901233553167d2e2) | Unreachable | Unreachable | 🔴 High |
| [GHSA-jjjh-jjxp-wpff](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e4fbcbfe15768769f) | Unreachable | Unreachable | 🔴 High |
| [GHSA-9gph-22xh-8x98](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f4fbcbfe1576876e7) | Unreachable | Unreachable | 🔴 High |
| [GHSA-27xj-rqx5-2255](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f41465cc922c959df) | Unreachable | Unreachable | 🔴 High |
| [GHSA-mc6h-4qgp-37qh](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e901233553167d27f) | Unreachable | Unreachable | 🔴 High |
| [GHSA-cvm9-fjm9-3572](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f4fbcbfe1576876b5) | Unreachable | Unreachable | 🔴 High |
| [GHSA-v3xw-c963-f5hc](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e901233553167d234) | Unreachable | Unreachable | 🔴 High |
| [GHSA-fqwf-pjwf-7vqv](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e41465cc922c95952) | Unreachable | Unreachable | 🔴 High |
| [GHSA-c2q3-4qrh-fm48](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f41465cc922c95986) | Unreachable | Unreachable | 🔴 High |
| [GHSA-qjw2-hr98-qgfh](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e41465cc922c95901) | Unreachable | Unreachable | 🔴 High |
| [GHSA-h3cw-g4mq-c5x2](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e41465cc922c9593d) | Unreachable | Unreachable | 🔴 High |
| [GHSA-95cm-88f5-f2c7](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59fd23bbf7fc73b0927) | Unreachable | Unreachable | 🔴 High |
| [GHSA-8c4j-34r4-xr8g](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f901233553167d2d0) | Unreachable | Unreachable | 🔴 High |
| [GHSA-r695-7vr9-jgc2](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e41465cc922c958ee) | Unreachable | Unreachable | 🔴 High |
| [GHSA-9m6f-7xcq-8vf8](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f4fbcbfe1576876e5) | Unreachable | Unreachable | 🔴 High |
| [GHSA-m6x4-97wx-4q27](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ec4f7e234f9813068) | Unreachable | Unreachable | 🔴 High |
| [GHSA-8w26-6f25-cm9x](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59fc4f7e234f98130c2) | Unreachable | Unreachable | 🔴 High |
| [GHSA-89qr-369f-5m5x](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59fdf7976d93f98ad10) | Unreachable | Unreachable | 🔴 High |
| [GHSA-rf6r-2c4q-2vwg](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ec4f7e234f981302c) | Unreachable | Unreachable | 🔴 High |
| [GHSA-57j2-w4cx-62h2](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59fd23bbf7fc73b0986) | Unreachable | Unreachable | 🔴 High |
| [GHSA-vfqx-33qm-g869](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ed23bbf7fc73b0890) | Unreachable | Unreachable | 🔴 High |
| [GHSA-rpr3-cw39-3pxh](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59edf7976d93f98ac7a) | Unreachable | Unreachable | 🔴 High |
| [GHSA-f9xh-2qgp-cq57](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f901233553167d2a2) | Unreachable | Unreachable | 🔴 High |
| [GHSA-wh8g-3j2c-rqj5](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ec4f7e234f981302a) | Unreachable | Unreachable | 🔴 High |
| [GHSA-c265-37vj-cwcc](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59fd23bbf7fc73b0925) | Unreachable | Unreachable | 🔴 High |
| [GHSA-r3gr-cxrf-hg25](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e901233553167d233) | Unreachable | Unreachable | 🔴 High |
| [GHSA-5949-rw7g-wx7w](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f41465cc922c95998) | Unreachable | Unreachable | 🔴 High |
| [GHSA-rgv9-q543-rqg4](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e4fbcbfe15768764c) | Unreachable | Unreachable | 🔴 High |
| [GHSA-58pp-9c76-5625](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f4fbcbfe1576876fc) | Unreachable | Unreachable | 🔴 High |
| [GHSA-288c-cq4h-88gq](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f901233553167d37a) | Unreachable | Unreachable | 🔴 High |
| [GHSA-h4rc-386g-6m85](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59e4fbcbfe157687699) | Unreachable | Unreachable | 🔴 High |
| [GHSA-9vvp-fxw6-jcxr](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59f4fbcbfe1576876e6) | Unreachable | Unreachable | 🔴 High |
| [GHSA-758m-v56v-grj4](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59fc4f7e234f98130c3) | Unreachable | Unreachable | 🔴 High |
| [GHSA-v585-23hc-c647](https://app.endorlabs.com/t/test_shiva.nitesh/findings/6710b59ed23bbf7fc73b088f) | Unreachable | Unreachable | 🔴 High |

</details>

---

### Reminders

- **Ignore**: If you don't wish to receive this update again, simply close this PR.
- **Test**: Remember to ensure your tests pass and ensure this change doesn't impact your application before you merge.

---

<p align="center">
  <sub>
    Generated by <a href="https://endorlabs.com/">Endor Labs
  </sub>
</p>
